### PR TITLE
fix: osx target/sdk version needs minor version

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -5,8 +5,8 @@ platform=$(uname -s)
 arch=$(uname -m)
 if [[ "$platform" == "Darwin" ]]; then
     if [[ "$arch" == "arm64" ]]; then
-        export MACOSX_DEPLOYMENT_TARGET=11
-        export MACOSX_SDK_VERSION=11
+        export MACOSX_DEPLOYMENT_TARGET=11.0
+        export MACOSX_SDK_VERSION=11.0
     elif [[ "$arch" == 'x86_64' ]]; then
         export MACOSX_DEPLOYMENT_TARGET=10.13
         export MACOSX_SDK_VERSION=10.13


### PR DESCRIPTION
`run_conda_forge_build_setup` from https://github.com/conda-forge/conda-forge-ci-setup-feedstock/blob/main/.scripts/run_osx_build.sh fails to download the SDK when set to `11` instead of `11.0`.

Needed for https://github.com/bioconda/bioconda-recipes/pull/46775