### PR TITLE
Bump macOS x86_64 SDK to 11.3

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -9,7 +9,7 @@ if [[ "$platform" == "Darwin" ]]; then
         export MACOSX_DEPLOYMENT_TARGET=11.3
         export MACOSX_SDK_VERSION=11.3
     elif [[ "$arch" == "x86_64" ]]; then
-        export MACOSX_DEPLOYMENT_TARGET=11.0
-        export MACOSX_SDK_VERSION=11.0
+        export MACOSX_DEPLOYMENT_TARGET=11.3
+        export MACOSX_SDK_VERSION=11.3
     fi
 fi


### PR DESCRIPTION
Should decrease intermittent `<SIGBART:6>` errors on OSX x86_64.